### PR TITLE
Fix PostCSS warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = async (css, mqs) => {
 				classPostfix(`${delimiter}${key}`)
 
 			return postcss([ fn ])
-				.process(css)
+				.process(css, { from: undefined })
 				.then(mqified => `
 					@media ${mq} {
 						${stripComments(mqified.css).trim()}


### PR DESCRIPTION
Remove warning:

> Without `from` option PostCSS could generate wrong source map and will not find Browserslist config. Set it to CSS file path or to `undefined` to prevent this warning.